### PR TITLE
CA - get virtual IPs from arista interfaces

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="sohonet-nsot-helpers",
-    version="0.1.27",
+    version="0.1.28",
     packages=find_packages(),
     author="Johan van den Dorpe",
     author_email="johan.vandendorpe@sohonet.com",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="sohonet-nsot-helpers",
-    version="0.1.26",
+    version="0.1.27",
     packages=find_packages(),
     author="Johan van den Dorpe",
     author_email="johan.vandendorpe@sohonet.com",

--- a/sohonet_nsot_helpers/napalm/eos_helpers.py
+++ b/sohonet_nsot_helpers/napalm/eos_helpers.py
@@ -271,6 +271,7 @@ def eos_get_interfaces_ip(self):
     interface_config = self.device.run_commands(["show running-config | section interface"],
                                                 encoding="text")[0]["output"]
     interface_acls = _textfsm_extractor("eos_show_running_config_interface_acl", interface_config)
+    interface_virtual_ips = _textfsm_extractor("eos_show_running_config_interface_virtual_router", interface_config)
 
     for interface_name, interface_details in interfaces_ipv4_out.items():
         ipv4_list = []
@@ -302,6 +303,12 @@ def eos_get_interfaces_ip(self):
 
         interfaces_ip[interface_name]["vrf"] = interface_details.get('vrf')
 
+    for i in interface_virtual_ips:
+        if i["ipaddress"]:
+            if i["interface"] in interfaces_ip.keys():
+                if i["ipaddress"] not in interfaces_ip[i["interface"]]["ipv4"].keys():
+                    interfaces_ip[i["interface"]]["ipv4"][i["ipaddress"].split("/")[0]] = {"prefix_length": i["ipaddress"].split("/")[-1]}
+    
     for interface_name, interface_details in interfaces_ipv6_out.items():
         ipv6_list = []
         if interface_name not in interfaces_ip.keys():

--- a/sohonet_nsot_helpers/textfsm_templates/eos_show_running_config_interface_virtual_router.tpl
+++ b/sohonet_nsot_helpers/textfsm_templates/eos_show_running_config_interface_virtual_router.tpl
@@ -1,0 +1,7 @@
+Value Interface (\S+)
+Value IPAddress (\S+)
+
+Start
+  ^interface ${Interface}
+  ^\s+ip virtual-router address ${IPAddress} -> Record
+  ^! -> Clearall


### PR DESCRIPTION
We are now using virtual IPs on aristas in a few locations (for VARP) so we need to capture those addresses as well as the normal IP address.