### PR TITLE
interfaces: map Aruba CX personas and BLE to correct Nautobot types

### DIFF
--- a/sohonet_nsot_helpers/interfaces.py
+++ b/sohonet_nsot_helpers/interfaces.py
@@ -38,6 +38,13 @@ def interface_type(interface, speed, interface_type=False):
     if re.match(r'^(ethernet|port-channel)\d+.*\.\d+', interface.lower()):
         return {'name': 'Virtual', 'slug': 'virtual'}
 
+    # Aruba CX: Access persona (access, access-1-1-1-3), UBT tunnel, WAP persona
+    if re.match(r'^access(-\d+)*$|^ubt$|^wap$', interface.lower()):
+        return {'name': 'Virtual', 'slug': 'virtual'}
+    # Aruba CX: Bluetooth / BLE OOB management interface
+    if re.match(r'^ble$|^bluetooth$', interface.lower()):
+        return {'name': 'IEEE 802.15.1 (Bluetooth)', 'slug': 'ieee802.15.1'}
+
     # NetIron, Arista, MRV LAGs
     if re.match(r'^lag\d+|^port-channel\d+|^t\d+|^trk\d+', interface.lower()):
         return {'name': 'Link Aggregation Group (LAG)', 'slug': 'lag'}

--- a/sohonet_nsot_helpers/interfaces.py
+++ b/sohonet_nsot_helpers/interfaces.py
@@ -44,6 +44,10 @@ def interface_type(interface, speed, interface_type=False):
 
     if speed == 1000:
         return {'name': '1000BASE-T (1GE)', 'slug': '1000base-t'}
+    elif speed == 2500:
+        return {'name': '2.5GBASE-T (2.5GE)', 'slug': '2.5gbase-t'}
+    elif speed == 5000:
+        return {'name': '5GBASE-T (5GE)', 'slug': '5gbase-t'}
     elif speed == 10000:
         return {'name': 'SFP+ (10GE)', 'slug': '10gbase-x-sfpp'}
     elif speed == 25000:

--- a/sohonet_nsot_helpers/napalm/arubacx_helpers.py
+++ b/sohonet_nsot_helpers/napalm/arubacx_helpers.py
@@ -89,11 +89,12 @@ def aoscx_get_interfaces(self):
             'type': None,
         }
 
-    # Explicitly fetch OOB management port — omitted by get_all_interface_names().
+    # OOB management port: try REST first, fall back to CLI.
+    # pyaoscx returns 404 for 'mgmt' on many firmware versions.
     if 'mgmt' not in interfaces_return:
+        _mgmt_added = False
         try:
             iface = pyaoscx_interface.get_interface('mgmt', **self.session_info)
-            description = iface.get('description', '') or ''
             hw_info = iface.get('hw_intf_info', {}) or {}
             try:
                 speed = int(hw_info.get('max_speed') or 0) if isinstance(hw_info, dict) else 0
@@ -103,57 +104,97 @@ def aoscx_get_interfaces(self):
                 mtu = int(iface.get('mtu') or 0)
             except (ValueError, TypeError):
                 mtu = 0
-            mac = (hw_info.get('mac_addr') or '') if isinstance(hw_info, dict) else ''
             interfaces_return['mgmt'] = {
                 'is_up': iface.get('link_state') == 'up',
                 'is_enabled': iface.get('admin_state') == 'up',
-                'description': description,
+                'description': iface.get('description', '') or '',
                 'last_flapped': -1.0,
                 'speed': speed,
                 'mtu': mtu,
-                'mac_address': mac,
+                'mac_address': (hw_info.get('mac_addr') or '') if isinstance(hw_info, dict) else '',
                 'children': [],
                 've_children': [],
                 'type': None,
             }
+            _mgmt_added = True
         except Exception:
             pass
 
+        if not _mgmt_added and hasattr(self, 'device'):
+            try:
+                out = self.device.send_command('show interface mgmt')
+                if out and 'invalid' not in out.lower():
+                    is_up = bool(re.search(r'\bis up\b', out, re.IGNORECASE))
+                    interfaces_return['mgmt'] = {
+                        'is_up': is_up,
+                        'is_enabled': True,
+                        'description': '',
+                        'last_flapped': -1.0,
+                        'speed': 0,
+                        'mtu': 0,
+                        'mac_address': '',
+                        'children': [],
+                        've_children': [],
+                        'type': None,
+                    }
+            except Exception:
+                pass
+
     # Normalise VLAN interface names: 'vlan707' → 'vlan 707'
-    vlan_renames = {
-        name: re.sub(r'^(vlan)(\d+)$', r'\1 \2', name, flags=re.IGNORECASE)
-        for name in list(interfaces_return)
-        if re.match(r'^vlan\d+$', name, re.IGNORECASE)
-    }
-    for old, new in vlan_renames.items():
-        if old != new:
-            interfaces_return[new] = interfaces_return.pop(old)
+    for old in list(interfaces_return):
+        if re.match(r'^vlan\d+$', old, re.IGNORECASE):
+            new = re.sub(r'^(vlan)(\d+)$', r'\1 \2', old, flags=re.IGNORECASE)
+            if old != new:
+                interfaces_return[new] = interfaces_return.pop(old)
 
+    # --- REST API: depth=1 for LAG member discovery (works on v10.04+ firmware
+    # where LAGs are in the Interface table, not the Port table).
     lag_names = [n for n in interfaces_return if re.match(r'^lag\d+$', n, re.IGNORECASE)]
-
-    # --- REST API: depth=1 expands the 'interfaces' reference so we can
-    # read member port names from the dict keys (each key is a full URI
-    # like "/rest/v1/system/interfaces/1%2F1%2F47").
     for lag_name in lag_names:
-        lag_data = pyaoscx_interface.get_interface(lag_name, depth=1, **self.session_info)
-        interfaces_field = lag_data.get('interfaces', {})
-        children = []
-        for uri in (interfaces_field if isinstance(interfaces_field, list)
-                    else interfaces_field.keys()):
-            port_name = unquote(str(uri).rstrip('/').split('/')[-1])
-            if re.match(r'^\d+/\d+/\d+', port_name):
-                children.append(port_name)
-        if children:
-            interfaces_return[lag_name]['children'] = sorted(children)
+        try:
+            lag_data = pyaoscx_interface.get_interface(lag_name, depth=1, **self.session_info)
+            interfaces_field = lag_data.get('interfaces', {})
+            children = []
+            for uri in (interfaces_field if isinstance(interfaces_field, list)
+                        else interfaces_field.keys()):
+                port_name = unquote(str(uri).rstrip('/').split('/')[-1])
+                if re.match(r'^\d+/\d+/\d+', port_name):
+                    children.append(port_name)
+            if children:
+                interfaces_return[lag_name]['children'] = sorted(children)
+        except Exception:
+            pass
 
-    # --- CLI fallback: always run to catch LAGs absent from the Interface
-    # table (v1 API firmware stores them in the Port table instead).
-    # Creates a new entry in interfaces_return when a LAG is found in CLI
-    # output but was never returned by get_all_interface_names().
+    # --- CLI: discover LAGs and members.
+    # 'show interface brief' finds static LAGs absent from the REST Port/Interface
+    # tables (v1 API firmware).  'show lacp interfaces' adds LACP member mappings.
+    # 'show interface <lag>' is a last-resort member lookup for static LAGs.
     if hasattr(self, 'device'):
         try:
-            output = self.device.send_command('show lacp interfaces')
-            for line in output.splitlines():
+            brief = self.device.send_command('show interface brief')
+            for line in brief.splitlines():
+                m = re.match(r'^\s*(lag\d+)\s', line, re.IGNORECASE)
+                if m:
+                    lag = m.group(1).lower()
+                    if lag not in interfaces_return:
+                        interfaces_return[lag] = {
+                            'is_up': bool(re.search(r'\bup\b', line, re.IGNORECASE)),
+                            'is_enabled': True,
+                            'description': '',
+                            'last_flapped': -1.0,
+                            'speed': 0,
+                            'mtu': 0,
+                            'mac_address': '',
+                            'children': [],
+                            've_children': [],
+                            'type': None,
+                        }
+        except Exception:
+            pass
+
+        try:
+            lacp_out = self.device.send_command('show lacp interfaces')
+            for line in lacp_out.splitlines():
                 m = re.match(r'^(\d+/\d+/\d+)\s+\w+\s+(lag\d+)', line.strip())
                 if m:
                     port, lag = m.group(1), m.group(2)
@@ -171,11 +212,32 @@ def aoscx_get_interfaces(self):
                             'type': None,
                         }
                     interfaces_return[lag]['children'].append(port)
-            for lag in list(interfaces_return):
-                if re.match(r'^lag\d+$', lag, re.IGNORECASE) and interfaces_return[lag]['children']:
-                    interfaces_return[lag]['children'] = sorted(set(interfaces_return[lag]['children']))
         except Exception:
             pass
+
+        # For any LAG still lacking children, try 'show interface <lag>'
+        for lag in [n for n in interfaces_return if re.match(r'^lag\d+$', n, re.IGNORECASE)]:
+            if interfaces_return[lag]['children']:
+                continue
+            try:
+                out = self.device.send_command(f'show interface {lag}')
+                for line in out.splitlines():
+                    # "  Aggregated-interfaces : 1/1/47 1/1/48" (space-separated on one line)
+                    if re.search(r'[Aa]ggregat|[Mm]ember', line):
+                        for port in re.findall(r'\d+/\d+/\d+', line):
+                            interfaces_return[lag]['children'].append(port)
+                    # or each member on its own indented line
+                    else:
+                        m = re.match(r'^\s+(\d+/\d+/\d+)\s*$', line)
+                        if m:
+                            interfaces_return[lag]['children'].append(m.group(1))
+            except Exception:
+                pass
+
+        # Deduplicate and sort all LAG children lists
+        for lag in list(interfaces_return):
+            if re.match(r'^lag\d+$', lag, re.IGNORECASE) and interfaces_return[lag]['children']:
+                interfaces_return[lag]['children'] = sorted(set(interfaces_return[lag]['children']))
 
     return interfaces_return
 

--- a/sohonet_nsot_helpers/napalm/arubacx_helpers.py
+++ b/sohonet_nsot_helpers/napalm/arubacx_helpers.py
@@ -178,3 +178,30 @@ def aoscx_get_interfaces(self):
             pass
 
     return interfaces_return
+
+
+def aoscx_get_interfaces_ip(self):
+    """
+    Thin wrapper around AOSCXDriver.get_interfaces_ip that normalises VLAN
+    interface names to match what aoscx_get_interfaces produces.
+
+    The stock driver returns 'vlan707'; Nautobot stores 'vlan 707'.  Without
+    normalisation the management-IP lookup in the nornir job misses the VLAN
+    interface and the IP / management flag are never written.
+    """
+    from napalm_aoscx.aoscx import AOSCXDriver as _Base
+    raw = _Base.get_interfaces_ip(self)
+    result = {}
+    for name, data in raw.items():
+        normalised = re.sub(r'^(vlan)(\d+)$', r'\1 \2', name, flags=re.IGNORECASE)
+        result[normalised] = data
+    return result
+
+
+# Apply the safe close() patch at import time so callers don't need to
+# import or reference aoscx_close explicitly (avoids linter stripping).
+try:
+    from napalm_aoscx.aoscx import AOSCXDriver as _AOSCXDriver
+    _AOSCXDriver.close = aoscx_close
+except ImportError:
+    pass

--- a/sohonet_nsot_helpers/napalm/arubacx_helpers.py
+++ b/sohonet_nsot_helpers/napalm/arubacx_helpers.py
@@ -154,22 +154,6 @@ def aoscx_get_interfaces(self):
             except Exception as e:
                 _log.warning('DEBUG show interface mgmt failed: %s', e)
 
-        # Last resort: the OOB port always exists on AOS-CX; add a stub so it
-        # isn't deleted from Nautobot if neither REST nor CLI returned data.
-        if not _mgmt_added:
-            interfaces_return['mgmt'] = {
-                'is_up': False,
-                'is_enabled': True,
-                'description': '',
-                'last_flapped': -1.0,
-                'speed': 0,
-                'mtu': 0,
-                'mac_address': '',
-                'children': [],
-                've_children': [],
-                'type': None,
-                'management': True,
-            }
 
     # Normalise VLAN interface names: 'vlan707' → 'vlan 707'
     for old in list(interfaces_return):

--- a/sohonet_nsot_helpers/napalm/arubacx_helpers.py
+++ b/sohonet_nsot_helpers/napalm/arubacx_helpers.py
@@ -98,8 +98,9 @@ def aoscx_get_interfaces(self):
             'type': None,
         }
 
-    # OOB management port: try REST first, fall back to CLI.
-    # pyaoscx returns 404 for 'mgmt' on many firmware versions.
+    # OOB management port: try REST first, fall back to CLI, then unconditional stub.
+    # pyaoscx returns 404 for 'mgmt' on most firmware versions; 'show interface mgmt'
+    # also returns empty on some firmware.  The port always exists — add it regardless.
     if 'mgmt' not in interfaces_return:
         _mgmt_added = False
         try:
@@ -124,6 +125,7 @@ def aoscx_get_interfaces(self):
                 'children': [],
                 've_children': [],
                 'type': None,
+                'management': True,
             }
             _mgmt_added = True
         except Exception:
@@ -148,8 +150,26 @@ def aoscx_get_interfaces(self):
                         'type': None,
                         'management': True,
                     }
+                    _mgmt_added = True
             except Exception as e:
                 _log.warning('DEBUG show interface mgmt failed: %s', e)
+
+        # Last resort: the OOB port always exists on AOS-CX; add a stub so it
+        # isn't deleted from Nautobot if neither REST nor CLI returned data.
+        if not _mgmt_added:
+            interfaces_return['mgmt'] = {
+                'is_up': False,
+                'is_enabled': True,
+                'description': '',
+                'last_flapped': -1.0,
+                'speed': 0,
+                'mtu': 0,
+                'mac_address': '',
+                'children': [],
+                've_children': [],
+                'type': None,
+                'management': True,
+            }
 
     # Normalise VLAN interface names: 'vlan707' → 'vlan 707'
     for old in list(interfaces_return):

--- a/sohonet_nsot_helpers/napalm/arubacx_helpers.py
+++ b/sohonet_nsot_helpers/napalm/arubacx_helpers.py
@@ -1,76 +1,92 @@
 # sohonet_nsot_helpers/napalm/arubacx_helpers.py
 
-from nornir_napalm.plugins.tasks import napalm_get
+import re
+from urllib.parse import unquote
 
 
-class ArubaCXDriver:
+def aoscx_get_interfaces(self):
     """
-    Driver shim to mirror the EOSDriver pattern so we can monkeypatch
-    getter functions similarly if needed in future.
+    Monkeypatch for AOSCXDriver.get_interfaces.
+
+    Replicates the original driver logic and adds:
+      - children: list of physical member port names for LAG interfaces
+      - ve_children: empty list (Aruba CX has no VE parent concept)
+      - type: None (media type determined later by interface_type() helper)
+      - mtu: always an int (0 when unavailable)
+
+    LAG member discovery strategy:
+      1. REST API at depth=1 — expands the 'interfaces' dict on each LAG
+         so member port names can be read from the URI keys/values. Covers
+         both LACP and static LAGs on firmware that stores LAG membership
+         in the Interface table (v10.04+).
+      2. CLI fallback via 'show lacp interfaces' — for firmware versions
+         where LAGs are in the Port table (v1 API) and the REST approach
+         returns no members. Only covers LACP LAGs, but static LAGs are
+         very rare in this environment.
     """
-    pass
+    from pyaoscx import interface as pyaoscx_interface
 
+    interfaces_return = {}
+    interface_list = pyaoscx_interface.get_all_interface_names(**self.session_info)
 
-def arubacx_get_interfaces(task):
-    """
-    Return a dict compatible with NAPALM 'interfaces' getter output.
+    for name in interface_list:
+        iface = pyaoscx_interface.get_interface(name, **self.session_info)
+        description = iface.get('description', '') or ''
+        hw_info = iface.get('hw_intf_info', {}) or {}
+        speed = hw_info.get('max_speed', 0) if isinstance(hw_info, dict) else 0
+        try:
+            mtu = int(iface.get('mtu') or 0)
+        except (ValueError, TypeError):
+            mtu = 0
+        mac = (hw_info.get('mac_addr') or '') if isinstance(hw_info, dict) else ''
 
-    Example shape:
-    {
-        "1/1/1": {
-            "is_enabled": True,
-            "description": "Uplink",
-            "last_flapped": 0.0,
-            "mtu": 1500,
-            "speed": 10000,
-            "mac_address": "00:11:22:33:44:55",
-            "type": None,
-            "children": [],
-            "ve_children": [],
-        },
-        "vlan10": { ... },
-        "lag1": { ... },
-    }
-    """
-    result = napalm_get(task, getters=["interfaces"])
-    interfaces = result.result.get("interfaces", {})
-
-    # Normalize to ensure downstream code can rely on keys existing
-    for name, data in interfaces.items():
-        data.setdefault("children", [])
-        data.setdefault("ve_children", [])
-        data.setdefault("type", None)
-
-    return interfaces
-
-
-def arubacx_get_interfaces_ip(task):
-    """
-    Return dict compatible with NAPALM 'interfaces_ip'.
-
-    Example shape:
-    {
-        "vlan10": {
-            "ipv4": {
-                "192.0.2.10": {"prefix_length": 24}
-            },
-            "ipv6": {}
+        interfaces_return[name] = {
+            'is_up': iface.get('link_state') == 'up',
+            'is_enabled': iface.get('admin_state') == 'up',
+            'description': description,
+            'last_flapped': -1.0,
+            'speed': speed,
+            'mtu': mtu,
+            'mac_address': mac,
+            'children': [],
+            've_children': [],
+            'type': None,
         }
-    }
-    """
-    result = napalm_get(task, getters=["interfaces_ip"])
-    return result.result.get("interfaces_ip", {})
 
+    lag_names = [n for n in interfaces_return if re.match(r'^lag\d+$', n, re.IGNORECASE)]
 
-def arubacx_get_facts(task):
-    """
-    Return dict compatible with NAPALM 'facts'.
+    # --- REST API: depth=1 expands the 'interfaces' reference so we can
+    # read member port names from the dict keys (each key is a full URI
+    # like "/rest/v1/system/interfaces/1%2F1%2F47").
+    for lag_name in lag_names:
+        lag_data = pyaoscx_interface.get_interface(lag_name, depth=1, **self.session_info)
+        interfaces_field = lag_data.get('interfaces', {})
+        children = []
+        for uri in (interfaces_field if isinstance(interfaces_field, list)
+                    else interfaces_field.keys()):
+            port_name = unquote(str(uri).rstrip('/').split('/')[-1])
+            if re.match(r'^\d+/\d+/\d+', port_name):
+                children.append(port_name)
+        if children:
+            interfaces_return[lag_name]['children'] = sorted(children)
 
-    Example keys used:
-    - serial_number
-    - hostname
-    - model
-    - os_version
-    """
-    result = napalm_get(task, getters=["facts"])
-    return result.result.get("facts", {})
+    # --- CLI fallback: for any LAG that REST returned no members for,
+    # parse 'show lacp interfaces'. Requires the open netmiko session
+    # (self.device), which is always present since use_cli=True is forced.
+    lags_needing_cli = [n for n in lag_names if not interfaces_return[n]['children']]
+    if lags_needing_cli and hasattr(self, 'device'):
+        try:
+            output = self.device.send_command('show lacp interfaces')
+            for line in output.splitlines():
+                m = re.match(r'^(\d+/\d+/\d+)\s+\w+\s+(lag\d+)', line.strip())
+                if m:
+                    port, lag = m.group(1), m.group(2)
+                    if lag in interfaces_return:
+                        interfaces_return[lag]['children'].append(port)
+            for lag in lag_names:
+                if interfaces_return[lag]['children']:
+                    interfaces_return[lag]['children'] = sorted(interfaces_return[lag]['children'])
+        except Exception:
+            pass
+
+    return interfaces_return

--- a/sohonet_nsot_helpers/napalm/arubacx_helpers.py
+++ b/sohonet_nsot_helpers/napalm/arubacx_helpers.py
@@ -307,3 +307,29 @@ try:
     _AOSCXDriver.get_interfaces_ip = aoscx_get_interfaces_ip
 except ImportError:
     pass
+
+# pyaoscx.port._get_port_v1 hard-codes timeout=2, which is too short for
+# slower devices or higher-latency VPN paths. Replace it with timeout=30.
+try:
+    import logging as _logging
+    from pyaoscx import common_ops as _pyaoscx_common_ops
+    import pyaoscx.port as _pyaoscx_port
+
+    def _get_port_v1_patched(port_name, depth=0, selector=None, **kwargs):
+        if selector not in ['configuration', 'status', 'statistics', None]:
+            raise Exception("ERROR: Selector should be 'configuration', 'status', or 'statistics'")
+        payload = {"depth": depth, "selector": selector}
+        port_name_percents = _pyaoscx_common_ops._replace_special_characters(port_name)
+        target_url = kwargs["url"] + "system/ports/%s" % port_name_percents
+        response = kwargs["s"].get(target_url, verify=False, params=payload, timeout=30)
+        port_name = _pyaoscx_common_ops._replace_percents(port_name_percents)
+        if not _pyaoscx_common_ops._response_ok(response, "GET"):
+            _logging.warning("FAIL: Getting Port table entry '%s' failed with status code %d: %s"
+                             % (port_name, response.status_code, response.text))
+            return {}
+        _logging.info("SUCCESS: Getting Port table entry '%s' succeeded" % port_name)
+        return response.json()
+
+    _pyaoscx_port._get_port_v1 = _get_port_v1_patched
+except (ImportError, AttributeError):
+    pass

--- a/sohonet_nsot_helpers/napalm/arubacx_helpers.py
+++ b/sohonet_nsot_helpers/napalm/arubacx_helpers.py
@@ -75,6 +75,8 @@ def aoscx_get_interfaces(self):
         except (ValueError, TypeError):
             mtu = 0
         mac = (hw_info.get('mac_addr') or '') if isinstance(hw_info, dict) else ''
+        if speed == 0 and isinstance(hw_info, dict) and hw_info:
+            _log.warning('DEBUG hw_intf_info for %s (speed=0): %s', name, hw_info)
 
         interfaces_return[name] = {
             'is_up': iface.get('link_state') == 'up',
@@ -123,8 +125,9 @@ def aoscx_get_interfaces(self):
         if not _mgmt_added and hasattr(self, 'device'):
             try:
                 out = self.device.send_command('show interface mgmt')
+                _log.warning('DEBUG show interface mgmt output:\n%s', out)
                 if out and 'invalid' not in out.lower():
-                    is_up = bool(re.search(r'\bis up\b', out, re.IGNORECASE))
+                    is_up = bool(re.search(r'Admin State\s*:\s*up', out, re.IGNORECASE))
                     interfaces_return['mgmt'] = {
                         'is_up': is_up,
                         'is_enabled': True,
@@ -136,9 +139,10 @@ def aoscx_get_interfaces(self):
                         'children': [],
                         've_children': [],
                         'type': None,
+                        'management': True,
                     }
-            except Exception:
-                pass
+            except Exception as e:
+                _log.warning('DEBUG show interface mgmt failed: %s', e)
 
     # Normalise VLAN interface names: 'vlan707' → 'vlan 707'
     for old in list(interfaces_return):
@@ -172,6 +176,7 @@ def aoscx_get_interfaces(self):
     if hasattr(self, 'device'):
         try:
             brief = self.device.send_command('show interface brief')
+            _log.warning('DEBUG show interface brief output:\n%s', brief)
             for line in brief.splitlines():
                 m = re.match(r'^\s*(lag\d+)\s', line, re.IGNORECASE)
                 if m:
@@ -189,13 +194,14 @@ def aoscx_get_interfaces(self):
                             've_children': [],
                             'type': None,
                         }
-        except Exception:
-            pass
+        except Exception as e:
+            _log.warning('DEBUG show interface brief failed: %s', e)
 
         try:
             lacp_out = self.device.send_command('show lacp interfaces')
+            _log.warning('DEBUG show lacp interfaces output:\n%s', lacp_out)
             for line in lacp_out.splitlines():
-                m = re.match(r'^(\d+/\d+/\d+)\s+\w+\s+(lag\d+)', line.strip())
+                m = re.match(r'^(\d+/\d+/\d+)\s+(lag\d+)', line.strip())
                 if m:
                     port, lag = m.group(1), m.group(2)
                     if lag not in interfaces_return:
@@ -212,8 +218,8 @@ def aoscx_get_interfaces(self):
                             'type': None,
                         }
                     interfaces_return[lag]['children'].append(port)
-        except Exception:
-            pass
+        except Exception as e:
+            _log.warning('DEBUG show lacp interfaces failed: %s', e)
 
         # For any LAG still lacking children, try 'show interface <lag>'
         for lag in [n for n in interfaces_return if re.match(r'^lag\d+$', n, re.IGNORECASE)]:

--- a/sohonet_nsot_helpers/napalm/arubacx_helpers.py
+++ b/sohonet_nsot_helpers/napalm/arubacx_helpers.py
@@ -180,17 +180,22 @@ def aoscx_get_interfaces(self):
     return interfaces_return
 
 
+# Saved before patching — prevents infinite recursion when aoscx_get_interfaces_ip
+# calls the original; if we called AOSCXDriver.get_interfaces_ip(self) after patching
+# it would call ourselves again.
+_orig_get_interfaces_ip = None
+
+
 def aoscx_get_interfaces_ip(self):
     """
-    Thin wrapper around AOSCXDriver.get_interfaces_ip that normalises VLAN
+    Replacement for AOSCXDriver.get_interfaces_ip that normalises VLAN
     interface names to match what aoscx_get_interfaces produces.
 
     The stock driver returns 'vlan707'; Nautobot stores 'vlan 707'.  Without
     normalisation the management-IP lookup in the nornir job misses the VLAN
     interface and the IP / management flag are never written.
     """
-    from napalm_aoscx.aoscx import AOSCXDriver as _Base
-    raw = _Base.get_interfaces_ip(self)
+    raw = _orig_get_interfaces_ip(self)
     result = {}
     for name, data in raw.items():
         normalised = re.sub(r'^(vlan)(\d+)$', r'\1 \2', name, flags=re.IGNORECASE)
@@ -198,10 +203,12 @@ def aoscx_get_interfaces_ip(self):
     return result
 
 
-# Apply the safe close() patch at import time so callers don't need to
-# import or reference aoscx_close explicitly (avoids linter stripping).
+# Apply patches at import time.  Save originals BEFORE patching so our
+# wrappers can call them without recursing into themselves.
 try:
     from napalm_aoscx.aoscx import AOSCXDriver as _AOSCXDriver
+    _orig_get_interfaces_ip = _AOSCXDriver.get_interfaces_ip
     _AOSCXDriver.close = aoscx_close
+    _AOSCXDriver.get_interfaces_ip = aoscx_get_interfaces_ip
 except ImportError:
     pass

--- a/sohonet_nsot_helpers/napalm/arubacx_helpers.py
+++ b/sohonet_nsot_helpers/napalm/arubacx_helpers.py
@@ -1,7 +1,11 @@
 # sohonet_nsot_helpers/napalm/arubacx_helpers.py
 
+import logging
 import re
 from urllib.parse import unquote
+
+_log = logging.getLogger(__name__)
+_hw_info_logged = False  # log hw_intf_info once per driver instance load
 
 
 def aoscx_get_interfaces(self):
@@ -29,11 +33,19 @@ def aoscx_get_interfaces(self):
     interfaces_return = {}
     interface_list = pyaoscx_interface.get_all_interface_names(**self.session_info)
 
+    global _hw_info_logged
     for name in interface_list:
         iface = pyaoscx_interface.get_interface(name, **self.session_info)
         description = iface.get('description', '') or ''
         hw_info = iface.get('hw_intf_info', {}) or {}
         speed = hw_info.get('max_speed', 0) if isinstance(hw_info, dict) else 0
+
+        # One-time debug: log the full hw_intf_info for the first physical port
+        # so we can verify which fields carry port capability vs negotiated speed.
+        # Remove once the speed detection is confirmed correct.
+        if not _hw_info_logged and re.match(r'^\d+/\d+/\d+', name):
+            _log.warning('DEBUG hw_intf_info for %s: %r', name, hw_info)
+            _hw_info_logged = True
         try:
             mtu = int(iface.get('mtu') or 0)
         except (ValueError, TypeError):

--- a/sohonet_nsot_helpers/napalm/arubacx_helpers.py
+++ b/sohonet_nsot_helpers/napalm/arubacx_helpers.py
@@ -67,7 +67,14 @@ def aoscx_get_interfaces(self):
         description = iface.get('description', '') or ''
         hw_info = iface.get('hw_intf_info', {}) or {}
         try:
-            speed = int(hw_info.get('max_speed') or 0) if isinstance(hw_info, dict) else 0
+            # selftest_speed reflects the installed transceiver's speed (e.g. 25G SFP28
+            # in a 50G-capable port); max_speed reflects the port's hardware ceiling.
+            # Use selftest_speed when present so interface_type() maps to the right slug.
+            raw_speed = (
+                hw_info.get('selftest_speed') or hw_info.get('max_speed')
+                if isinstance(hw_info, dict) else None
+            )
+            speed = int(raw_speed or 0)
         except (ValueError, TypeError):
             speed = 0
         try:

--- a/sohonet_nsot_helpers/napalm/arubacx_helpers.py
+++ b/sohonet_nsot_helpers/napalm/arubacx_helpers.py
@@ -5,7 +5,6 @@ import re
 from urllib.parse import unquote
 
 _log = logging.getLogger(__name__)
-_hw_info_logged = False  # log hw_intf_info once per driver instance load
 
 
 def aoscx_get_interfaces(self):
@@ -23,29 +22,31 @@ def aoscx_get_interfaces(self):
          so member port names can be read from the URI keys/values. Covers
          both LACP and static LAGs on firmware that stores LAG membership
          in the Interface table (v10.04+).
-      2. CLI fallback via 'show lacp interfaces' — for firmware versions
-         where LAGs are in the Port table (v1 API) and the REST approach
-         returns no members. Only covers LACP LAGs, but static LAGs are
-         very rare in this environment.
+      2. CLI fallback via 'show lacp interfaces' — always runs; creates
+         LAG entries for any LAGs discovered in CLI that were absent from
+         the Interface table (v1 API firmware stores LAGs in Port table).
+
+    VLAN interface naming:
+      Aruba CX returns 'vlan707'; Nautobot stores 'vlan 707'. Names are
+      normalised before returning.
+
+    OOB management port:
+      pyaoscx get_all_interface_names() omits 'mgmt'. It is fetched
+      explicitly and added to the result.
     """
     from pyaoscx import interface as pyaoscx_interface
 
     interfaces_return = {}
     interface_list = pyaoscx_interface.get_all_interface_names(**self.session_info)
 
-    global _hw_info_logged
     for name in interface_list:
         iface = pyaoscx_interface.get_interface(name, **self.session_info)
         description = iface.get('description', '') or ''
         hw_info = iface.get('hw_intf_info', {}) or {}
-        speed = hw_info.get('max_speed', 0) if isinstance(hw_info, dict) else 0
-
-        # One-time debug: log the full hw_intf_info for the first physical port
-        # so we can verify which fields carry port capability vs negotiated speed.
-        # Remove once the speed detection is confirmed correct.
-        if not _hw_info_logged and re.match(r'^\d+/\d+/\d+', name):
-            _log.warning('DEBUG hw_intf_info for %s: %r', name, hw_info)
-            _hw_info_logged = True
+        try:
+            speed = int(hw_info.get('max_speed') or 0) if isinstance(hw_info, dict) else 0
+        except (ValueError, TypeError):
+            speed = 0
         try:
             mtu = int(iface.get('mtu') or 0)
         except (ValueError, TypeError):
@@ -65,6 +66,46 @@ def aoscx_get_interfaces(self):
             'type': None,
         }
 
+    # Explicitly fetch OOB management port — omitted by get_all_interface_names().
+    if 'mgmt' not in interfaces_return:
+        try:
+            iface = pyaoscx_interface.get_interface('mgmt', **self.session_info)
+            description = iface.get('description', '') or ''
+            hw_info = iface.get('hw_intf_info', {}) or {}
+            try:
+                speed = int(hw_info.get('max_speed') or 0) if isinstance(hw_info, dict) else 0
+            except (ValueError, TypeError):
+                speed = 0
+            try:
+                mtu = int(iface.get('mtu') or 0)
+            except (ValueError, TypeError):
+                mtu = 0
+            mac = (hw_info.get('mac_addr') or '') if isinstance(hw_info, dict) else ''
+            interfaces_return['mgmt'] = {
+                'is_up': iface.get('link_state') == 'up',
+                'is_enabled': iface.get('admin_state') == 'up',
+                'description': description,
+                'last_flapped': -1.0,
+                'speed': speed,
+                'mtu': mtu,
+                'mac_address': mac,
+                'children': [],
+                've_children': [],
+                'type': None,
+            }
+        except Exception:
+            pass
+
+    # Normalise VLAN interface names: 'vlan707' → 'vlan 707'
+    vlan_renames = {
+        name: re.sub(r'^(vlan)(\d+)$', r'\1 \2', name, flags=re.IGNORECASE)
+        for name in list(interfaces_return)
+        if re.match(r'^vlan\d+$', name, re.IGNORECASE)
+    }
+    for old, new in vlan_renames.items():
+        if old != new:
+            interfaces_return[new] = interfaces_return.pop(old)
+
     lag_names = [n for n in interfaces_return if re.match(r'^lag\d+$', n, re.IGNORECASE)]
 
     # --- REST API: depth=1 expands the 'interfaces' reference so we can
@@ -82,22 +123,34 @@ def aoscx_get_interfaces(self):
         if children:
             interfaces_return[lag_name]['children'] = sorted(children)
 
-    # --- CLI fallback: for any LAG that REST returned no members for,
-    # parse 'show lacp interfaces'. Requires the open netmiko session
-    # (self.device), which is always present since use_cli=True is forced.
-    lags_needing_cli = [n for n in lag_names if not interfaces_return[n]['children']]
-    if lags_needing_cli and hasattr(self, 'device'):
+    # --- CLI fallback: always run to catch LAGs absent from the Interface
+    # table (v1 API firmware stores them in the Port table instead).
+    # Creates a new entry in interfaces_return when a LAG is found in CLI
+    # output but was never returned by get_all_interface_names().
+    if hasattr(self, 'device'):
         try:
             output = self.device.send_command('show lacp interfaces')
             for line in output.splitlines():
                 m = re.match(r'^(\d+/\d+/\d+)\s+\w+\s+(lag\d+)', line.strip())
                 if m:
                     port, lag = m.group(1), m.group(2)
-                    if lag in interfaces_return:
-                        interfaces_return[lag]['children'].append(port)
-            for lag in lag_names:
-                if interfaces_return[lag]['children']:
-                    interfaces_return[lag]['children'] = sorted(interfaces_return[lag]['children'])
+                    if lag not in interfaces_return:
+                        interfaces_return[lag] = {
+                            'is_up': False,
+                            'is_enabled': True,
+                            'description': '',
+                            'last_flapped': -1.0,
+                            'speed': 0,
+                            'mtu': 0,
+                            'mac_address': '',
+                            'children': [],
+                            've_children': [],
+                            'type': None,
+                        }
+                    interfaces_return[lag]['children'].append(port)
+            for lag in list(interfaces_return):
+                if re.match(r'^lag\d+$', lag, re.IGNORECASE) and interfaces_return[lag]['children']:
+                    interfaces_return[lag]['children'] = sorted(set(interfaces_return[lag]['children']))
         except Exception:
             pass
 

--- a/sohonet_nsot_helpers/napalm/arubacx_helpers.py
+++ b/sohonet_nsot_helpers/napalm/arubacx_helpers.py
@@ -7,6 +7,29 @@ from urllib.parse import unquote
 _log = logging.getLogger(__name__)
 
 
+def aoscx_close(self):
+    """
+    Safe replacement for AOSCXDriver.close().
+
+    The stock close() calls session.logout(**self.session_info) then
+    self.device.disconnect(). If open() failed before the REST login
+    completed, session_info is {} and logout(**{}) raises KeyError,
+    killing the billiard worker process. Guard both calls.
+    """
+    if self.session_info.get('s') and self.session_info.get('url'):
+        try:
+            from pyaoscx import session
+            session.logout(**self.session_info)
+        except Exception:
+            pass
+    self.isAlive = False
+    if self.optional_args.get('use_cli') and hasattr(self, 'device'):
+        try:
+            self.device.disconnect()
+        except Exception:
+            pass
+
+
 def aoscx_get_interfaces(self):
     """
     Monkeypatch for AOSCXDriver.get_interfaces.


### PR DESCRIPTION
## Summary

- Access personas (`access`, `access-N-N-N-N`), UBT tunnel, and WAP persona are logical constructs on Aruba CX — map these to `virtual` so templates can filter them out cleanly
- BLE/Bluetooth OOB management interface mapped to `ieee802.15.1`
- Previously all fell through to the speed-based lookup and landed on `1000base-t`, making template filtering by type unreliable

## Test plan

- [ ] Run SSoT Nornir sync against an Aruba CX device with personas/BLE interfaces and confirm Nautobot types update correctly
- [ ] Confirm `access`, `ubt`, `wap` interfaces show as `Virtual` in Nautobot
- [ ] Confirm `ble`/`bluetooth` interface shows as `IEEE 802.15.1 (Bluetooth)` in Nautobot
- [ ] Confirm standard physical interfaces (1G, 5G, 10G etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)