### PR TITLE
arubacx: normalise LAG interface names to 'lag N' with space

### DIFF
--- a/sohonet_nsot_helpers/napalm/arubacx_helpers.py
+++ b/sohonet_nsot_helpers/napalm/arubacx_helpers.py
@@ -256,6 +256,13 @@ def aoscx_get_interfaces(self):
             if re.match(r'^lag\d+$', lag, re.IGNORECASE) and interfaces_return[lag]['children']:
                 interfaces_return[lag]['children'] = sorted(set(interfaces_return[lag]['children']))
 
+    # Normalise LAG interface names: 'lag10' → 'lag 10' (Nautobot stores with space)
+    for old in list(interfaces_return):
+        if re.match(r'^lag\d+$', old, re.IGNORECASE):
+            new = re.sub(r'^(lag)(\d+)$', r'\1 \2', old, flags=re.IGNORECASE)
+            if old != new:
+                interfaces_return[new] = interfaces_return.pop(old)
+
     return interfaces_return
 
 


### PR DESCRIPTION
Nautobot stores Aruba LAG interfaces as 'lag 10' (with space), but the driver was producing 'lag10'. Mirror the existing VLAN normalisation pass so SSoT matches existing device records instead of creating duplicates.